### PR TITLE
Remove deprecated UseHG2

### DIFF
--- a/plotly/plotlyfig_aux/helpers/isHG2.m
+++ b/plotly/plotlyfig_aux/helpers/isHG2.m
@@ -1,4 +1,4 @@
 function check = isHG2
 %check for HG2 update
-check = feature('UseHG2'); 
+check = ~verLessThan('matlab','8.4.0');
 end


### PR DESCRIPTION
MATLAB 2016b throws an error on `feature('UseHG2')`:
```
Error using feature
UseHG2 will be removed in a future release. Use ~verLessThan('matlab','8.4.0') instead.

Error in isHG2 (line 3)
check = feature('UseHG2');

Error in plotlyfig/update (line 517)
            if isHG2

Error in plotlyfig (line 203)
                obj.update;

Error in fig2plotly (line 44)
p = plotlyfig(varargin{:});
```

Fixes #97.