### PR TITLE
check OpenURL before launching browser in offline mode

### DIFF
--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -443,7 +443,9 @@ classdef plotlyfig < handle
                 end
             else
                 obj.url = plotlyoffline(obj);   
-                web(obj.url, '-browser');
+                if obj.PlotOptions.OpenURL
+                    web(obj.url, '-browser');
+                end
             end 
            
         end


### PR DESCRIPTION
Fixes #117. This check is necessary otherwise when parameters 'offline':true and 'open':false are passed to fig2plotly, plotly still tries to open up the browser.