### PR TITLE
fix dead link to plotly docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and Plotly figure retrieval:
 ```
 
 ### DOCUMENTATION:
-Live here: [https://plot.ly/MATLAB](https://plot.ly/MATLAB)
+Live here: [https://plot.ly/matlab](https://plot.ly/matlab)
 
 ### CONTACT:
 - <chuck@plot.ly>


### PR DESCRIPTION
The original link with all caps does not work.