### PR TITLE
Added option to disable inclusion of plotly js in offline html output.

### DIFF
--- a/plotly/plotly_offline_aux/plotlyoffline.m
+++ b/plotly/plotly_offline_aux/plotlyoffline.m
@@ -3,21 +3,29 @@ function response = plotlyoffline(plotlyfig)
     % the current working directory. The file will be saved as: 
     % 'plotlyfig.PlotOptions.FileName'.html. 
     
-    % grab the bundled dependencies
-    userhome = getuserdir();
-    plotly_config_folder   = fullfile(userhome,'.plotly');
-    plotly_js_folder = fullfile(plotly_config_folder, 'plotlyjs');
-    bundle_name = 'plotly-matlab-offline-bundle.js'; 
-    bundle_file = fullfile(plotly_js_folder, bundle_name);
-    
-    % check that the bundle exists 
-    try
-        bundle = fileread(bundle_file); 
-    catch
-        error(['Error reading: %s.\nPlease download the required ', ... 
-               'dependencies using: >>getplotlyoffline \n', ...
-               'or contact support@plot.ly for assistance.'], ...
-               bundle_file);   
+    % create dependency string unless not required
+    if plotlyfig.PlotOptions.IncludePlotlyjs
+        % grab the bundled dependencies
+        userhome = getuserdir();
+        plotly_config_folder   = fullfile(userhome,'.plotly');
+        plotly_js_folder = fullfile(plotly_config_folder, 'plotlyjs');
+        bundle_name = 'plotly-matlab-offline-bundle.js';
+        bundle_file = fullfile(plotly_js_folder, bundle_name);
+
+        % check that the bundle exists
+        try
+            bundle = fileread(bundle_file);
+            % template dependencies
+            dep_script = sprintf('<script type="text/javascript">%s</script>\n', ...
+                bundle);
+        catch
+            error(['Error reading: %s.\nPlease download the required ', ...
+                   'dependencies using: >>getplotlyoffline \n', ...
+                   'or contact support@plot.ly for assistance.'], ...
+                   bundle_file);
+        end
+    else
+        dep_script = '';
     end
     
     % handle plot div specs
@@ -35,15 +43,11 @@ function response = plotlyoffline(plotlyfig)
     jdata = m2json(plotlyfig.data); 
     jlayout = m2json(plotlyfig.layout);
     clean_jdata = escapechars(jdata); 
-    clean_jlayout = escapechars(jlayout); 
-   
-    % template dependencies 
-    dep_script = sprintf('<script type="text/javascript">%s</script>', ...
-                         bundle); 
+    clean_jlayout = escapechars(jlayout);
                      
     % template environment vars        
     plotly_domain = plotlyfig.UserData.PlotlyDomain;
-    env_script = sprintf(['\n<script type="text/javascript">', ...
+    env_script = sprintf(['<script type="text/javascript">', ...
                           'window.PLOTLYENV=window.PLOTLYENV || {};', ...
                           'window.PLOTLYENV.BASE_URL="%s";', ...
                           'Plotly.LINKTEXT="%s";', ...

--- a/plotly/plotlyfig.m
+++ b/plotly/plotlyfig.m
@@ -63,6 +63,7 @@ classdef plotlyfig < handle
             obj.PlotOptions.Offline = false;
             obj.PlotOptions.ShowLinkText = true; 
             obj.PlotOptions.LinkText = obj.get_link_text; 
+            obj.PlotOptions.IncludePlotlyjs = true;
             
             %-PlotlyDefaults-%
             obj.PlotlyDefaults.MinTitleMargin = 80;
@@ -176,6 +177,9 @@ classdef plotlyfig < handle
                         end
                         if(strcmpi(varargin{a},'linktext'))
                             obj.PlotOptions.LinkText = varargin{a+1};
+                        end
+                        if(strcmpi(varargin{a},'include_plotlyjs'))
+                            obj.PlotOptions.IncludePlotlyjs = varargin{a+1};
                         end
                         if(strcmpi(varargin{a},'layout'))
                             obj.layout= varargin{a+1};


### PR DESCRIPTION
Fixes #111 . The argument 'include_plotlyjs' accepts a boolean value and enables the
removal of the plotly.js dependency from the html output in offline mode.

i.e.: fig2plotly(gcf, 'offline', true, 'include_plotlyjs', false, 'filename', 'sine wave');